### PR TITLE
Release/0.1.0 alpha

### DIFF
--- a/var/m0_term_uart-ba/m0_term_uart-ba.ino
+++ b/var/m0_term_uart-ba/m0_term_uart-ba.ino
@@ -1,4 +1,4 @@
-// Wed Sep 16 01:25:51 UTC 2020
+// Wed Sep 16 02:41:31 UTC 2020
 
 // redo entire sketch using peeks - 16 September 2020
 

--- a/var/m0_term_uart-ba/terminal.cpp
+++ b/var/m0_term_uart-ba/terminal.cpp
@@ -1,4 +1,4 @@
-// Wed Sep 16 02:26:06 UTC 2020 lumex-bb- // converse with STM32F407
+// Wed Sep 16 02:41:31 UTC 2020 lumex-bb- // converse with STM32F407
 
 // chvargu  kidari  nefalo  gelron  pibulatto
 
@@ -98,7 +98,7 @@ void setup() {
   }
 
   Serial.println ("terminal - based on the Forth-like interpreter\n");
-  Serial.println ("    16 SEP 2020     cc388e60943b-b01 ");
+  Serial.println ("    16 SEP 2020  02:44 UTC or later ..  cb3f915d6839-a01 ");
   SERIAL.begin(115200); // TX/RX pair
 }
 


### PR DESCRIPTION
First release.  Works 2020 16 September, primary project.

STM32F407 Discovery, C.H. Ting's eForth v7.20, USART converser.

This project is in lieu of CP2104 or equivalent; allows the Linux host PC
to converse with eForth.